### PR TITLE
Fixed an incorrect example in control flow

### DIFF
--- a/individual_modules/introduction_to_python/control_flow.ipynb
+++ b/individual_modules/introduction_to_python/control_flow.ipynb
@@ -218,18 +218,51 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "887b2841-3115-4819-b734-7cc094034ab3",
-   "metadata": {},
+   "execution_count": null,
+   "id": "5059803d-6218-4b8b-a701-2356cb164761",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-output"
+    ]
+   },
    "outputs": [],
    "source": [
-    "if False:\n",
-    "    if 4 > 5:\n",
-    "        print('A')\n",
-    "    elif 4 == 5:\n",
-    "        print('B')\n",
-    "    elif 4 < 5:\n",
-    "        print('C')"
+    "if 4 > 5:\n",
+    "    print('A')\n",
+    "elif 4 == 5:\n",
+    "    print('B')\n",
+    "elif 4 < 5:\n",
+    "    print('C')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "417c7f00-3f5b-415a-9dca-c19f4c5720da",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": [
+     "remove-output"
+    ]
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/Users/lb788/Documents/CfRR/incorrect_example/CfRR_Courses/individual_modules/introduction_to_python\n"
+     ]
+    }
+   ],
+   "source": [
+    "!pwd"
    ]
   },
   {

--- a/individual_modules/introduction_to_python/control_flow.ipynb
+++ b/individual_modules/introduction_to_python/control_flow.ipynb
@@ -240,32 +240,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 2,
-   "id": "417c7f00-3f5b-415a-9dca-c19f4c5720da",
-   "metadata": {
-    "editable": true,
-    "slideshow": {
-     "slide_type": ""
-    },
-    "tags": [
-     "remove-output"
-    ]
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "/Users/lb788/Documents/CfRR/incorrect_example/CfRR_Courses/individual_modules/introduction_to_python\n"
-     ]
-    }
-   ],
-   "source": [
-    "!pwd"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "id": "9a05c50a-f06a-44a4-867a-fda1d045e319",
    "metadata": {


### PR DESCRIPTION
This PR fixes a mistake on the control flow example for the introduction to python course within the new website format. The output for a question was suppressed with `if False:` to suppress the output. This same functionality has been achieved with jupyter notebook meta data to make the code example clearer to participants of the workshop. 