### PR TITLE
Improve the meta landing pages for the coding practices and languages for both the self study and quizes

### DIFF
--- a/cfrr_program_details/coding_languages_self_study.ipynb
+++ b/cfrr_program_details/coding_languages_self_study.ipynb
@@ -9,6 +9,44 @@
     "\n",
     "The following pages provide the self-study notes for the courses that CfRR offers in coding languages. "
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "579bda23-a0e7-49a5-ad3f-b455994e2459",
+   "metadata": {},
+   "source": [
+    "## Julia \n",
+    "\n",
+    "[Clickable Link to Coding Language Courses for Julia](../course_homepages/julia.ipynb)\n",
+    "\n",
+    "These self-study courses provide a comprehensive exploration of the Julia programming language, specifically designed for reproducible scientific research. Key topics include data manipulation and analysis, advanced visualization techniques, performance optimization, and the development of reproducible workflows using Julia's robust libraries and tools. Additionally, the course covers best practices for writing efficient, scalable, and reliable code to support a wide range of research applications.\n",
+    "\n",
+    "## Python \n",
+    "\n",
+    "[Clickable Link to Coding Language Courses for Python](../course_homepages/python.ipynb)\n",
+    "\n",
+    "These self-study courses provide a comprehensive introduction to Python programming, equipping participants with foundational knowledge of data types, control flow, and function implementation. Building on these basics, the courses delve into advanced data manipulation, visualization techniques, and machine learning applications, emphasizing efficient handling of large datasets and predictive modeling. With a focus on reproducibility, participants will also learn to manage dependencies, validate analyses, and ensure their work is robust and replicable.\n",
+    "\n",
+    "## R \n",
+    "\n",
+    "[Clickable Link to Coding Language Courses for R](../course_homepages/R.ipynb)\n",
+    "\n",
+    "These self-study courses provide a comprehensive introduction to using R for data analysis, covering essential concepts such as data manipulation, visualization, and programming fundamentals. Participants will gain a strong foundation in regression analysis, from basic models to advanced techniques like interactions and multi-level models, with a focus on tailoring methods to specific research questions. Emphasizing practical skills, the courses teach students to work with structured data, conduct analyses effectively, and document their work for reproducibility.\n",
+    "\n",
+    "## UNIX \n",
+    "\n",
+    "[Clickable Link to Coding Language Courses for UNIX](../course_homepages/unix.ipynb)\n",
+    "\n",
+    "These self-study courses provide an introduction to the Unix shell, focusing on navigating filesystems, inspecting and manipulating files, and automating tasks with scripting. Participants will develop skills to manage workflows efficiently through the command line, moving beyond IDEs and notebooks to run programs directly in a Unix environment. Emphasizing practical applications, the courses equip students with foundational tools for effective and streamlined system interaction.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5ad4faec-7a82-4f3b-a3df-86d4ca32953c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/cfrr_program_details/coding_practices_self_study.ipynb
+++ b/cfrr_program_details/coding_practices_self_study.ipynb
@@ -9,6 +9,36 @@
     "\n",
     "The following pages provide the self-study notes for the courses that CfRR offers in coding practices. "
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b00cafdb-9a54-4e49-88da-24c62d4e28a6",
+   "metadata": {},
+   "source": [
+    "## Computational Thinking\n",
+    "\n",
+    "[Clickable Link to Coding Practices Courses for Computational Thinking](../course_homepages/computational_thinking.ipynb)\n",
+    "\n",
+    "These self-study courses provide an introduction to computational thinking, emphasizing the importance of algorithms in coding and problem-solving. Participants will develop a foundational understanding of computational approaches and learn to design effective algorithms for a variety of tasks. The courses also focus on improving debugging skills by distinguishing between syntax errors and algorithmic issues, fostering more efficient troubleshooting.\n",
+    "\n",
+    "## High Performance Computing\n",
+    "\n",
+    "[Clickable Link to Coding Practices Courses for High Performance Computing](../course_homepages/high_performance_computing.ipynb)\n",
+    "\n",
+    "These self-study courses provide a comprehensive introduction to high-performance computing (HPC), focusing on using clusters for managing large computational workloads. Participants will learn to navigate HPC environments, manage job scheduling, and efficiently parallelize tasks using array jobs and other techniques. The courses also cover the fundamentals of parallel computing, including distributed and shared-memory parallelism, with practical experience in writing and optimizing parallel code using MPI and multithreading.\n",
+    "\n",
+    "## Software Development\n",
+    "\n",
+    "[Clickable Link to Coding Practices Courses for Software Development](../course_homepages/software_development.ipynb)\n",
+    "\n",
+    "These self-study courses provide an introduction to best practices in software development, focusing on creating reproducible and collaborative research code. Participants will learn techniques to make their code accessible and useful to others, enhancing the impact and reliability of their work. The courses also lay the groundwork for more advanced topics in software development, preparing students for intermediate-level learning.\n",
+    "\n",
+    "## Version Control\n",
+    "\n",
+    "[Clickable Link to Coding Practices Courses for Version Control](../course_homepages/version_control.ipynb)\n",
+    "\n",
+    "These self-study courses provide a comprehensive introduction to version control, focusing on managing software development using Git and collaborating through platforms like GitHub. Participants will gain foundational skills in repository management, essential Git commands, and best practices for sharing and maintaining code. Building on these basics, the courses explore advanced Git configurations, branching strategies, and techniques for rewriting history, equipping learners with robust tools for effective and collaborative version control workflows.\n"
+   ]
   }
  ],
  "metadata": {

--- a/where_is_my_understanding/coding_languages_quiz.ipynb
+++ b/where_is_my_understanding/coding_languages_quiz.ipynb
@@ -9,6 +9,37 @@
     "\n",
     "The following pages provide the quizes for the courses that CfRR offers in coding languages. "
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "df1016ef-5de7-44ff-95a6-e2b14c3c8925",
+   "metadata": {},
+   "source": [
+    "## Julia \n",
+    "\n",
+    "[Clickable Link to Coding Languages Quizes for Julia](julia.ipynb)\n",
+    "\n",
+    "These quizzes test your understanding of Julia's core syntax and basic operations, helping you assess whether the courses align with your current skill level. They focus on topics such as variable declaration, array manipulation, Julia’s data types, control flow constructs, and its distinguishing features compared to other programming languages.\n",
+    "\n",
+    "## Python \n",
+    "\n",
+    "[Clickable Link to Coding Languages Quizes for Python](python.ipynb)\n",
+    "\n",
+    "\n",
+    "These quizzes test your understanding of Python programming and its application in data analysis, helping you determine if the courses are suited to your needs. They assess knowledge of Python syntax, including variable assignment, data types, control flow, functions, modules, and common data structures like lists and dictionaries. Additionally, they evaluate your ability to handle data workflows, clean and transform datasets, and create visualizations using tools such as Pandas and Matplotlib.\n",
+    "\n",
+    "## R \n",
+    "\n",
+    "[Clickable Link to Coding Languages Quizes for R](R.ipynb)\n",
+    "\n",
+    "These quizzes test your understanding of R programming, data analysis, and regression techniques, helping you determine if the courses align with your current skills. They assess knowledge of fundamental topics such as variable assignment, data structures, control flow, and basic data manipulation, including filtering, reshaping, and combining datasets. Additionally, they evaluate your ability to perform regression analysis, assess model assumptions, interpret results, and address advanced challenges like multicollinearity and overfitting using diagnostic tools and R packages like dplyr and tidyr.\n",
+    "\n",
+    "## UNIX \n",
+    "\n",
+    "[Clickable Link to Coding Languages Quizes for UNIX](unix.ipynb)\n",
+    "\n",
+    "These quizzes test your understanding of fundamental Unix concepts, helping you assess whether the courses are suited to your needs. They evaluate your ability to navigate the command line, manage files, and work with commands like ls, cd, and mkdir. Additionally, they assess your understanding of directory structures, permissions, and environment variables."
+   ]
   }
  ],
  "metadata": {

--- a/where_is_my_understanding/coding_practices_quiz.ipynb
+++ b/where_is_my_understanding/coding_practices_quiz.ipynb
@@ -9,6 +9,37 @@
     "\n",
     "The following pages provide the quizes for the courses that CfRR offers in coding practices. "
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7bdc79a5-c0f9-4251-9547-e49053bb0805",
+   "metadata": {},
+   "source": [
+    "## Computational Thinking\n",
+    "\n",
+    "[Clickable Link to Coding Practices Quizes for Computational Thinking](computational_thinking_overview.ipynb)\n",
+    "\n",
+    "These quizzes test your understanding of key computational thinking concepts, helping you evaluate whether the courses are suited to your skill level. They assess your ability to approach problems through decomposition, algorithmic reasoning, and abstraction. Additionally, they evaluate your proficiency in structuring tasks into logical steps and translating conceptual solutions into reproducible workflows.\n",
+    "\n",
+    "## High Performance Computing \n",
+    "\n",
+    "[Clickable Link to Coding Practices Quizes for High Performance Computing](high_performance_computing.ipynb)\n",
+    "\n",
+    "\n",
+    "These quizzes test your understanding of high-performance and parallel computing concepts, helping you determine if the courses align with your current knowledge. They assess your ability to navigate HPC environments, understand cluster architectures, and manage job scheduling systems for optimizing computational tasks. Additionally, they evaluate your grasp of parallel computing fundamentals, including concurrency, data parallelism, task distribution, and strategies to avoid pitfalls such as race conditions and deadlocks.\n",
+    "\n",
+    "## Software Development\n",
+    "\n",
+    "[Clickable Link to Coding Practices Quizes for Software Development](software_development.ipynb)\n",
+    "\n",
+    "These quizzes test your understanding of best practices in software development, helping you determine if the courses match your current skill level. They assess your knowledge of version control, testing, documentation, and code organization, as well as your familiarity with agile practices and continuous integration. Additionally, they evaluate your ability to implement collaborative workflows for efficient and maintainable projects.\n",
+    "\n",
+    "## Version Control\n",
+    "\n",
+    "[Clickable Link to Coding Practices Quizes for Version Control](version_control.ipynb)\n",
+    "\n",
+    "These quizzes test your understanding of version control concepts and practices, helping you assess whether the courses align with your skill level. They evaluate your knowledge of using Git for tracking changes, branching, merging, and resolving conflicts to maintain clear project histories and collaborate effectively. Additionally, they assess your proficiency with advanced techniques, including branching models, rebasing, and managing complex workflows in collaborative environments.\n"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
This PR adds links and summaries to the meta pages of the website for coding languages and practices, as done for other meta pages in #217 