### PR TITLE
fix: wrap variable name in parentheses to avoid UndefVarError

### DIFF
--- a/individual_modules/introduction_to_julia/introduction_to_julia.ipynb
+++ b/individual_modules/introduction_to_julia/introduction_to_julia.ipynb
@@ -161,7 +161,7 @@
     "55\n",
     "\n",
     "julia> function greet(name)\n",
-    "           println(\"Hello, $name!\")\n",
+    "           println(\"Hello, $(name)!\")\n",
     "       end\n",
     "\n",
     "julia> greet(\"Julia\")\n",


### PR DESCRIPTION
closes #272