### PR TITLE
Fix link text for Tar archive in local_branches.ipynb

### DIFF
--- a/individual_modules/introduction_to_version_control/local_branches.ipynb
+++ b/individual_modules/introduction_to_version_control/local_branches.ipynb
@@ -31,7 +31,7 @@
     "the following archives:\n",
     "\n",
     "* As a Zip archive: [git-good-practice.zip](downloads/git-good-practice.zip)\n",
-    "* As a Tar archive: [git-good-practice.zip](downloads/git-good-practice.tar)\n",
+    "* As a Tar archive: [git-good-practice.tar](downloads/git-good-practice.tar)\n",
     "\n",
     "You should place the archive contents in your own `git-good-practice` repository\n",
     "(note: make sure to preserve the directory structure: the file\n",


### PR DESCRIPTION
Copy-paste error shows "zip" extension repeated in link text.