### PR TITLE
[WIP] Add merge conflicts section to branches_and_merging page (#392)

### DIFF
--- a/individual_modules/intermediate_version_control/branches_and_merging.ipynb
+++ b/individual_modules/intermediate_version_control/branches_and_merging.ipynb
@@ -183,6 +183,7 @@
     "```sh\n",
     "git commit\n",
     "```\n",
+    "Most modern code editors should help you find any merge conflicts and provide buttons or shortcuts for resolving the changes, but the above steps will work everywhere.\n",
     "\n",
     "## Exercise\n",
     "\n",


### PR DESCRIPTION
This PR adds a section on merge conflicts to the self-study notes in
/individual_modules/intermediate_version_control/branches_and_merging.html

- Explains what merge conflicts are
- Shows conflict markers example
- Provides simple steps to resolve conflicts

Resolves issue #392 
