### PR TITLE
Add Security Check GitHub Action 

### DIFF
--- a/.github/actions/setup-gitleaks/action.yml
+++ b/.github/actions/setup-gitleaks/action.yml
@@ -1,0 +1,28 @@
+name: Setup Gitleaks
+description: Install a pinned Gitleaks release on Linux GitHub Actions runners.
+
+inputs:
+  version:
+    description: Gitleaks version tag to install.
+    required: false
+    default: v8.24.2
+
+runs:
+  using: composite
+  steps:
+    - name: Install Gitleaks
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        version="${{ inputs.version }}"
+        version_number="${version#v}"
+        archive="gitleaks_${version_number}_linux_x64.tar.gz"
+        install_dir="$RUNNER_TEMP/gitleaks"
+
+        mkdir -p "$install_dir"
+        curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/${version}/${archive}" \
+          | tar -xz -C "$install_dir" gitleaks
+
+        chmod +x "$install_dir/gitleaks"
+        echo "$install_dir" >> "$GITHUB_PATH"

--- a/.github/scripts/render_gitleaks_report.py
+++ b/.github/scripts/render_gitleaks_report.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Render a redacted Gitleaks JSON report as a PR comment."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+TARGET_TYPES = "`.ipynb`, `.md`, `.R`, `.py`, `.yml`, `.yaml`, and log files"
+
+
+def markdown_escape(value: Any) -> str:
+    text = "" if value is None else str(value)
+    return text.replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def normalize_path(path_value: Any, source_root: Path | None) -> str:
+    path = "" if path_value is None else str(path_value)
+    if not path:
+        return "unknown"
+
+    file_path = Path(path)
+    if source_root and file_path.is_absolute():
+        try:
+            return str(file_path.relative_to(source_root))
+        except ValueError:
+            return path
+    return path
+
+
+def load_findings(report_path: Path) -> list[dict[str, Any]]:
+    if not report_path.exists() or report_path.stat().st_size == 0:
+        return []
+
+    with report_path.open(encoding="utf-8") as handle:
+        data = json.load(handle)
+
+    if isinstance(data, list):
+        return [item for item in data if isinstance(item, dict)]
+    return []
+
+
+def render(args: argparse.Namespace) -> str:
+    findings = load_findings(args.report)
+    lines = [
+        "### Secret Scanning Report",
+        "",
+        f"Gitleaks scanned the pull request working tree for {TARGET_TYPES}.",
+        "Secret values are redacted from this report.",
+        (
+            "This automated scan is a safeguard, not a guarantee. Please still review the "
+            "changed files yourself and take care that no sensitive data is being leaked."
+        ),
+        "",
+    ]
+
+    if args.exit_code not in (0, 1):
+        lines.extend(
+            [
+                f"Gitleaks exited with code `{args.exit_code}`. Check the workflow logs for details.",
+                "",
+            ]
+        )
+
+    if not findings:
+        lines.append("No potential secrets were detected.")
+        return "\n".join(lines) + "\n"
+
+    lines.extend(
+        [
+            f"Potential secrets detected: `{len(findings)}`.",
+            "",
+            "| Rule | File | Line |",
+            "| --- | --- | --- |",
+        ]
+    )
+
+    source_root = args.source_root.resolve() if args.source_root else None
+    for finding in findings[: args.max_findings]:
+        rule = markdown_escape(finding.get("RuleID", "unknown"))
+        file_name = markdown_escape(normalize_path(finding.get("File"), source_root))
+        line = markdown_escape(finding.get("StartLine") or finding.get("Line") or "unknown")
+        lines.append(f"| `{rule}` | `{file_name}` | `{line}` |")
+
+    remaining = len(findings) - args.max_findings
+    if remaining > 0:
+        lines.extend(
+            [
+                "",
+                f"Showing the first {args.max_findings} findings; {remaining} more are in the workflow logs.",
+            ]
+        )
+
+    lines.extend(
+        [
+            "",
+            (
+                "Remove the secret from the PR. If the value is a deliberate fake token in "
+                "course material, add a narrow allowlist entry."
+            ),
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--report", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--source-root", type=Path)
+    parser.add_argument("--exit-code", type=int, default=0)
+    parser.add_argument("--max-findings", type=int, default=25)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    args.output.write_text(render(args), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/scan_generated_logs.sh
+++ b/.github/scripts/scan_generated_logs.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+scan_root="${1:-_build}"
+config_path="${2:-.gitleaks.toml}"
+
+if [ ! -d "$scan_root" ]; then
+  echo "Generated log directory not found: $scan_root"
+  exit 0
+fi
+
+mapfile -d '' log_files < <(
+  find "$scan_root" -type f \
+    \( -name "*.log" -o -name "*.err" -o -name "*.out" \) \
+    -print0
+)
+
+if [ "${#log_files[@]}" -eq 0 ]; then
+  echo "No generated logs found to scan."
+  exit 0
+fi
+
+config_args=()
+if [ -f "$config_path" ]; then
+  config_args+=(--config "$config_path")
+fi
+
+scan_exit=0
+for log_file in "${log_files[@]}"; do
+  echo "Scanning generated log: $log_file"
+  set +e
+  gitleaks dir "$log_file" \
+    "${config_args[@]}" \
+    --redact=100 \
+    --no-banner \
+    --log-level warn \
+    --exit-code 1
+  exit_code=$?
+  set -e
+
+  if [ "$exit_code" -ne 0 ]; then
+    scan_exit="$exit_code"
+  fi
+done
+
+exit "$scan_exit"

--- a/.github/workflows/build-book.yml
+++ b/.github/workflows/build-book.yml
@@ -33,13 +33,23 @@ jobs:
         path: _build/.jupyter_cache
         key: jupyter-book-cache-${{ hashFiles('pyproject.toml') }}
 
+    - name: Install Gitleaks
+      uses: ./.github/actions/setup-gitleaks
+      with:
+        version: v8.24.2
+
     # Build the book
     - name: Build the book
       run: |
         poetry run jupyter-book build .
 
+    - name: Scan generated logs for secrets
+      if: always()
+      run: bash .github/scripts/scan_generated_logs.sh _build .gitleaks.toml
+
     # Always upload logs, even if build succeeds
     - name: Upload error logs
+      if: always()
       uses: actions/upload-artifact@v4
       with:
         name: error-logs

--- a/.github/workflows/deploy-book.yml
+++ b/.github/workflows/deploy-book.yml
@@ -40,10 +40,19 @@ jobs:
         path: _build/.jupyter_cache
         key: jupyter-book-cache-${{ hashFiles('pyproject.toml') }}
 
+    - name: Install Gitleaks
+      uses: ./.github/actions/setup-gitleaks
+      with:
+        version: v8.24.2
+
     # Build the book
     - name: Build the book
       run: |
         poetry run jupyter-book build .
+
+    - name: Scan generated logs for secrets
+      if: always()
+      run: bash .github/scripts/scan_generated_logs.sh _build .gitleaks.toml
 
     # Upload the book's HTML as an artifact
     - name: Upload artifact

--- a/.github/workflows/secret-scanning.yml
+++ b/.github/workflows/secret-scanning.yml
@@ -1,0 +1,147 @@
+name: Secret Scanning
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  GITLEAKS_VERSION: v8.24.2
+
+jobs:
+  secret-scanning-comment:
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Checkout base branch helpers
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Checkout pull request head
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install Gitleaks
+        uses: ./base/.github/actions/setup-gitleaks
+        with:
+          version: ${{ env.GITLEAKS_VERSION }}
+
+      - name: Run Gitleaks and save output
+        id: gitleaks
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          report="$RUNNER_TEMP/gitleaks-report.json"
+          comment="$GITHUB_WORKSPACE/secret_scan_output.md"
+          config="$GITHUB_WORKSPACE/base/.gitleaks.toml"
+          ignore="$GITHUB_WORKSPACE/base/.gitleaksignore"
+
+          args=(
+            dir "$GITHUB_WORKSPACE/pr"
+            --config "$config"
+            --redact=100
+            --no-banner
+            --log-level warn
+            --report-format json
+            --report-path "$report"
+            --exit-code 1
+          )
+
+          if [ -f "$ignore" ]; then
+            args+=(--gitleaks-ignore-path "$ignore")
+          fi
+
+          set +e
+          gitleaks "${args[@]}"
+          scan_exit=$?
+          set -e
+
+          if [ ! -f "$report" ]; then
+            printf '[]\n' > "$report"
+          fi
+
+          python "$GITHUB_WORKSPACE/base/.github/scripts/render_gitleaks_report.py" \
+            --report "$report" \
+            --output "$comment" \
+            --source-root "$GITHUB_WORKSPACE/pr" \
+            --exit-code "$scan_exit"
+
+          echo "scan_exit=$scan_exit" >> "$GITHUB_OUTPUT"
+
+      - name: Debug comment body
+        run: |
+          echo "------- BEGIN COMMENT BODY -------"
+          cat secret_scan_output.md
+          echo "-------- END COMMENT BODY --------"
+
+      - name: Find previous PR comment
+        id: find_comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: github-actions[bot]
+          body-includes: '### Secret Scanning Report'
+
+      - name: Create or update PR comment with Gitleaks results
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: secret_scan_output.md
+          comment-id: ${{ steps.find_comment.outputs.comment-id }}
+          edit-mode: replace
+
+      - name: Fail if potential secrets were detected
+        if: steps.gitleaks.outputs.scan_exit != '0'
+        run: exit 1
+
+  secret-scanning:
+    if: github.event_name != 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Install Gitleaks
+        uses: ./.github/actions/setup-gitleaks
+        with:
+          version: ${{ env.GITLEAKS_VERSION }}
+
+      - name: Scan repository for secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          config_args=()
+          if [ -f .gitleaks.toml ]; then
+            config_args+=(--config .gitleaks.toml)
+          fi
+
+          gitleaks dir . \
+            "${config_args[@]}" \
+            --redact=100 \
+            --no-banner \
+            --log-level warn \
+            --exit-code 1

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,4 @@
+title = "CfRR Courses Gitleaks configuration"
+
+[extend]
+useDefault = true

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,1 @@
+688183193f7844ec7d3306a8f7586fe63f1a0b14:lib/vis-9.1.2/vis-network.min.js:generic-api-key:26

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.2
+    hooks:
+      - id: gitleaks

--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ Notes:
 - Poetry installs from `pyproject.toml` (the same source used in GitHub Actions).
 - If you prefer an activated shell instead of prefixing commands with `poetry run`, use `poetry shell`.
 
+### Secret scanning before commits
+
+This repository includes a Gitleaks pre-commit hook for catching accidental credentials before they are committed. Install `pre-commit`, then enable the hook:
+
+```bash
+pre-commit install
+```
+
+To scan the repository manually:
+
+```bash
+pre-commit run gitleaks --all-files
+```
+
 ## Build and preview the website
 
 Build the Jupyter Book:
@@ -116,3 +130,6 @@ This project uses GitHub Actions to build, test, and deploy the website:
 - `.github/workflows/build-book.yml`: builds the book on pull requests to `main`.
 - `.github/workflows/deploy-book.yml`: builds and deploys `_build/html` to GitHub Pages on pushes to `main` (and on a schedule).
 - `.github/workflows/accessibility*.yml`: builds the book and runs accessibility checks (see above).
+- `.github/workflows/secret-scanning.yml`: runs Gitleaks and posts a PR comment with redacted secret-scanning results.
+
+The build and deploy workflows also scan generated `_build/` log files after the Jupyter Book build. Repository administrators should enable GitHub secret scanning and push protection in the repository's code security settings where available.


### PR DESCRIPTION
This PR adds secret scanning to both CI and local pre-commit checks using Gitleaks.

What has been added:

- A Gitleaks pre-commit hook via `.pre-commit-config.yaml`.
- A `.gitleaks.toml` config that extends the default Gitleaks rules.
- A new GitHub Actions workflow that scans PRs and posts/updates a redacted PR comment, similar to the accessibility checker.
- Secret scanning for generated `_build/` log files in the existing build/deploy workflows.
- README guidance for running the scan locally.
- GitHub secret scanning and push protection have also been enabled for the public repository.

The PR comment produced by the workflow includes a caveat that the automated scan is a safeguard, not a guarantee. Contributors and reviewers still need to check changed files themselves and take care not to leak sensitive data.

Validation performed:

- Current tree Gitleaks scan: `0` findings.
- History scan after `.gitleaksignore`: `0` findings.
- GitHub secret-scanning alerts API: no open alerts returned.
- YAML/config parsing passed.
- `git diff --check` passed.